### PR TITLE
fix: Force OAuth2 V1 handler and fix Railway cross-domain auth

### DIFF
--- a/src/main/java/com/movietracker/api/config/SecurityConfig.java
+++ b/src/main/java/com/movietracker/api/config/SecurityConfig.java
@@ -85,9 +85,9 @@ public class SecurityConfig {
         
         // Only configure OAuth2 login if enabled and handlers are available
         if (oauth2Enabled && oAuth2AuthenticationFailureHandler != null) {
-            // Use V2 handler if available (with session management), fallback to V1 handler
-            var successHandler = oAuth2AuthenticationSuccessHandlerV2 != null ? 
-                oAuth2AuthenticationSuccessHandlerV2 : oAuth2AuthenticationSuccessHandler;
+            // TEMPORARY FIX: Force V1 handler for Railway deployment to avoid session issues
+            // V2 handler requires custom session management that doesn't work with Spring Security OAuth2
+            var successHandler = oAuth2AuthenticationSuccessHandler;
             
             if (successHandler != null) {
                 System.out.println("Configuring OAuth2 with handler: " + successHandler.getClass().getSimpleName());


### PR DESCRIPTION
Changes:
- Force SecurityConfig to use V1 handler instead of V2
- Fix cross-domain authentication by passing auth data via URL parameters
- Remove cookie-based auth that doesn't work across Railway subdomains
- Add detailed logging for Railway debugging

This resolves the "Missing authentication data" error by ensuring auth tokens and user data reach the frontend callback properly.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Description
Brief description of changes made in this PR.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Testing
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed
- [ ] Security scan completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Security Considerations
- [ ] No sensitive information is exposed
- [ ] Authentication/authorization is properly implemented
- [ ] Input validation is in place
- [ ] No SQL injection vulnerabilities
- [ ] JWT tokens are handled securely

## Railway Deployment
- [ ] Environment variables are properly configured
- [ ] Database migrations (if any) are documented
- [ ] Health check endpoint works correctly
